### PR TITLE
Fixed a typo in the Mojolicious::Lite POD

### DIFF
--- a/lib/Mojolicious/Plugin/Cron.pm
+++ b/lib/Mojolicious/Plugin/Cron.pm
@@ -104,7 +104,7 @@ Mojolicious::Plugin::Cron - a Cron-like helper for Mojolicious and Mojolicious::
 
   # Mojolicious::Lite
 
-  plugin Cron( '*/5 9-17 * * *' => sub {
+  plugin Cron => ( '*/5 9-17 * * *' => sub {
       # do someting non-blocking but useful
   });
 


### PR DESCRIPTION
I think a mistake exist in your POD. 

Dunno if the README.md is auto-generated from POD, but I guess so, so I didn't corrected it. 

If it isn't a typo, my pull request should be turned to a bug because I can't manage to instantiate it this way with `Mojolicious::Lite`.